### PR TITLE
Cambio fecha venta

### DIFF
--- a/PersistenciaBazar/src/main/java/entidades/Venta.java
+++ b/PersistenciaBazar/src/main/java/entidades/Venta.java
@@ -50,7 +50,7 @@ public class Venta implements Serializable {
     @Column(name = "monto_total")
     private Float montoTotal;
 
-    @Column(name = "fecha_venta", columnDefinition = "DATE")
+    @Column(name = "fecha_venta", columnDefinition = "TIMESTAMP")
     private LocalDateTime fechaVenta;
     
     @Column(name = "metodo_pago")

--- a/PersistenciaBazar/src/main/java/persistencia/PersistenciaBazar.java
+++ b/PersistenciaBazar/src/main/java/persistencia/PersistenciaBazar.java
@@ -18,7 +18,6 @@ import persistencia.excepciones.PersistenciaBazarException;
 import subsistemas.excepciones.DAOException;
 import subsistemas.interfaces.*;
 
-
 /**
  *
  * @author saul

--- a/PersistenciaBazar/src/main/java/pruebas/PersistenciaBazarPrueba2.java
+++ b/PersistenciaBazar/src/main/java/pruebas/PersistenciaBazarPrueba2.java
@@ -31,10 +31,9 @@ public class PersistenciaBazarPrueba2 {
         PersistenciaBazar persistencia = PersistenciaBazar.getInstance();
         
         
-        //pruebasUsuarios(persistencia);
+        pruebasUsuarios(persistencia);
         pruebasProductos(persistencia);
-        //pruebasVentas(persistencia);
-        
+        pruebasVentas(persistencia);
         
     }
     
@@ -42,9 +41,9 @@ public class PersistenciaBazarPrueba2 {
         UsuarioDTO usuario = new UsuarioDTO();
         usuario.setNombre("Pedro");
         usuario.setApellido("Lopez");
-        usuario.setTelefono("6442269619");
+        usuario.setTelefono("6444223344");
         usuario.setContrasena("admin12345");
-        usuario.setPuesto(UsuarioDTO.Puesto.CAJERO);
+        usuario.setPuesto(UsuarioDTO.Puesto.ADMIN);
         
         DireccionDTO direccion = new DireccionDTO();
         


### PR DESCRIPTION
Se hizo que las fechas de las ventas sean TIMESTAMP y no DATE ya que no permitia sacar ventas por intervalos de horas especificas (NOTA: SIGUE SIN HACERLO, DEBE SER SOLUCIONADO)